### PR TITLE
remove blacklisted actors and make corresponding spec pending. min. p…

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,4 +1,6 @@
 class GamesController < ApplicationController
+  before_action :clear_paths_and_games, only: [:create, :create_demo]
+
   def show
     @game = Game.find(params[:id])
     render json: { starting_actor: @game.starting_actor, ending_actor: @game.ending_actor, game_id: @game.id }
@@ -25,6 +27,11 @@ class GamesController < ApplicationController
   end
 
   private
+  def clear_paths_and_games
+    Path.delete_all
+    Game.delete_all
+  end
+
   def set_demo_starting_actor
     @game.starting_actor = Actor.find_or_create_by_tmdb_id(params[:starting_tmdb])
   end

--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -119,7 +119,7 @@ class Actor < ApplicationRecord
   end
 
   def self.minimum_popularity
-    7.00
+    9.00
   end
 
   def self.kevin_bacon_tmdb_id
@@ -128,9 +128,9 @@ class Actor < ApplicationRecord
 
   def cold_bacon_blacklist
     [
-      71580, # Benedict Cumbersnooch
-      127558, # Andrea Riseborough
-      62965, # Miranda Hart
+      # 71580, # Benedict Cumbersnooch
+      # 127558, # Andrea Riseborough
+      # 62965, # Miranda Hart
     ]
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -3,9 +3,9 @@ class Game < ApplicationRecord
   belongs_to :starting_actor, class_name: "Actor"
   belongs_to :ending_actor, class_name: "Actor"
 
-  before_validation :set_starting_actor, :set_ending_actor
-
   validates_presence_of :starting_actor, :ending_actor
+
+  before_validation :set_starting_actor, :set_ending_actor
 
   def set_starting_actor
     self.starting_actor ||= Actor.random_qualified_starting_actors.first

--- a/spec/models/actor_spec.rb
+++ b/spec/models/actor_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Actor, type: :model do
   end
 
   context "is on the cold bacon blacklist" do
-    it "does not save the actor" do
+    xit "does not save the actor" do
       actor = Actor.new(name: "Benedict Cumberbatch", tmdb_id: 71580, image_url: "profile.jpg", popularity: 60)
       expect(actor.save).to be false
     end


### PR DESCRIPTION
…opularity set to 9. before action for games controller deletes all Game and Path entries in db